### PR TITLE
Minor refactorings of ApplicationStartupException

### DIFF
--- a/Toastify/src/App.xaml.cs
+++ b/Toastify/src/App.xaml.cs
@@ -123,7 +123,7 @@ namespace Toastify
                 // Modify RollingFileAppender's destination
                 var rollingFileAppender = (RollingFileAppender)loggerRepository.GetAppenders().FirstOrDefault(appender => appender.Name == "RollingFileAppender");
                 if (rollingFileAppender == null)
-                    throw new ApplicationStartupException("RollingFileAppender not found", false);
+                    throw new ApplicationStartupException("RollingFileAppender not found");
                 rollingFileAppender.File = Path.Combine(AppArgs.LogDirectory, "Toastify.log");
 
                 // Set RollingFileAppender's minimum log level

--- a/Toastify/src/Core/ApplicationStartupException.cs
+++ b/Toastify/src/Core/ApplicationStartupException.cs
@@ -5,44 +5,34 @@ namespace Toastify.Core
 {
     public class ApplicationStartupException : ApplicationException
     {
-        public ApplicationStartupException() : this(true)
+        public ApplicationStartupException(string message) : base(message + Environment.NewLine + CreateMessage())
         {
         }
 
-        public ApplicationStartupException(bool spotifyStatus) : base(CreateMessage(spotifyStatus))
+        private static string CreateMessage()
         {
-        }
+            var nl = Environment.NewLine;
+            if (Spotify.Instance == null)
+                return string.Join(nl, "No Spotify instance created.");
 
-        public ApplicationStartupException(string message) : this(message, true)
-        {
-        }
-
-        public ApplicationStartupException(string message, bool spotifyStatus) : base($"{CreateMessage(spotifyStatus)}\nAdditional details:\n{message}")
-        {
-        }
-
-        private static string CreateMessage(bool spotifyStatus = true)
-        {
             List<string> messages = new List<string>();
+            messages.Add("Spotify is running: " + Spotify.Instance.IsRunning);
 
-            if (spotifyStatus)
+            var status = Spotify.Instance.Status;
+            messages.Add("Status: ");
+            if (status == null)
+                messages.Add("null");
+            else
             {
-                bool spotifyInstanceCreated = Spotify.Instance != null;
-                if (spotifyInstanceCreated)
-                {
-                    bool spotifyIsRunning = Spotify.Instance.IsRunning;
-                    messages.Add($"Spotify is running: {spotifyIsRunning}");
-
-                    var status = Spotify.Instance.Status;
-                    messages.Add(status != null
-                        ? $"Status: {status.Online}, {status.Running}, {status.Version}, {status.ClientVersion}, {status.Track != null}"
-                        : "Status: null");
-                }
-                else
-                    messages.Add("Spotify instance not created!");
+                // TODO: add a status.toString() to Spotify API and replace this:
+                messages.Add(nl + "-- Online: " + status.Online);
+                messages.Add(nl + "-- Running: " + status.Running);
+                messages.Add(nl + "-- Version: " + status.Version);
+                messages.Add(nl + "-- Client Version: " + status.ClientVersion);
+                messages.Add(nl + "--  has Track: " + (status.Track != null));
             }
 
-            return string.Join(Environment.NewLine, messages);
+            return string.Join(nl, messages);
         }
     }
 }

--- a/Toastify/src/Core/ApplicationStartupException.cs
+++ b/Toastify/src/Core/ApplicationStartupException.cs
@@ -12,24 +12,32 @@ namespace Toastify.Core
         private static string CreateMessage()
         {
             var nl = Environment.NewLine;
-            if (Spotify.Instance == null)
-                return string.Join(nl, "No Spotify instance created.");
+
+            // Touching Spotify.Instance forces instance creation, but it fails if called too early
+            try
+            {
+                var tmp = Spotify.Instance;
+            }
+            catch (NullReferenceException)
+            {
+                return "Spotify instance status: not yet created.";
+            }
 
             List<string> messages = new List<string>();
-            messages.Add("Spotify is running: " + Spotify.Instance.IsRunning);
+            messages.Add("Spotify instance running status: " + Spotify.Instance.IsRunning);
 
             var status = Spotify.Instance.Status;
-            messages.Add("Status: ");
+            messages.Add("Spotify instance Status: ");
             if (status == null)
                 messages.Add("null");
             else
             {
                 // TODO: add a status.toString() to Spotify API and replace this:
-                messages.Add(nl + "-- Online: " + status.Online);
-                messages.Add(nl + "-- Running: " + status.Running);
-                messages.Add(nl + "-- Version: " + status.Version);
-                messages.Add(nl + "-- Client Version: " + status.ClientVersion);
-                messages.Add(nl + "--  has Track: " + (status.Track != null));
+                messages.Add("-- Online: " + status.Online);
+                messages.Add("-- Running: " + status.Running);
+                messages.Add("-- Version: " + status.Version);
+                messages.Add("-- Client Version: " + status.ClientVersion);
+                messages.Add("--  has Track: " + (status.Track != null));
             }
 
             return string.Join(nl, messages);

--- a/Toastify/src/Core/ApplicationStartupException.cs
+++ b/Toastify/src/Core/ApplicationStartupException.cs
@@ -11,31 +11,41 @@ namespace Toastify.Core
 
         private static string CreateMessage()
         {
-            // Touching Spotify.Instance forces instance creation, but it fails if called too early. Therefore, a try is needed.
+            // Touching Spotify.Instance forces instance creation if none, but it fails if called too early. 
+            // Therefore, a try is needed.
             try
             {
-                var tmp = Spotify.Instance;
+                // unused variable is needed to build the project
+                var burner = Spotify.Instance;
             }
             catch (NullReferenceException)
             {
-                return "Spotify instance status: not yet created.";
+                return "\tSpotify instance status: not yet created.";
             }
 
             List<string> messages = new List<string>();
-            messages.Add("Spotify instance running status: " + Spotify.Instance.IsRunning);
+            messages.Add($"\tSpotify instance running status: {Spotify.Instance.IsRunning}");
 
             var status = Spotify.Instance.Status;
-            messages.Add("Spotify instance Status: ");
             if (status == null)
-                messages.Add("null");
+                messages.Add("\tSpotify instance status: null");
             else
             {
-                // TODO: add a status.toString() to Spotify API and replace this:
-                messages.Add("-- Online: " + status.Online);
-                messages.Add("-- Running: " + status.Running);
-                messages.Add("-- Version: " + status.Version);
-                messages.Add("-- Client Version: " + status.ClientVersion);
-                messages.Add("--  has Track: " + (status.Track != null));
+                messages.Add("\tSpotify instance status: ");
+                messages.Add($"\t-- Version:\t{status.Version}");
+                messages.Add($"\t-- Client Version:\t{status.ClientVersion}");
+                messages.Add($"\t-- Playing:\t{status.Playing}");
+                messages.Add($"\t-- Shuffle:\t{status.Shuffle}");
+                messages.Add($"\t-- Repeat:\t{status.Repeat}");
+                messages.Add($"\t-- Play Enabled:\t{status.PlayEnabled}");
+                messages.Add($"\t-- Prev Enabled:\t{status.PrevEnabled}");
+                messages.Add($"\t-- Next Enabled:\t{status.NextEnabled}");
+                messages.Add($"\t-- has Track:\t{status.Track != null}");
+                messages.Add($"\t-- Server Time:\t{status.ServerTime}");
+                messages.Add($"\t-- Volume:\t{status.Volume}");
+                messages.Add($"\t-- Online:\t{status.Online}");
+                messages.Add($"\t-- has OpenGraphState: {status.OpenGraphState != null}");
+                messages.Add($"\t-- Running:\t{status.Running}");
             }
 
             return string.Join(Environment.NewLine, messages);

--- a/Toastify/src/Core/ApplicationStartupException.cs
+++ b/Toastify/src/Core/ApplicationStartupException.cs
@@ -11,9 +11,7 @@ namespace Toastify.Core
 
         private static string CreateMessage()
         {
-            var nl = Environment.NewLine;
-
-            // Touching Spotify.Instance forces instance creation, but it fails if called too early
+            // Touching Spotify.Instance forces instance creation, but it fails if called too early. Therefore, a try is needed.
             try
             {
                 var tmp = Spotify.Instance;
@@ -40,7 +38,7 @@ namespace Toastify.Core
                 messages.Add("--  has Track: " + (status.Track != null));
             }
 
-            return string.Join(nl, messages);
+            return string.Join(Environment.NewLine, messages);
         }
     }
 }

--- a/Toastify/src/Core/Spotify.cs
+++ b/Toastify/src/Core/Spotify.cs
@@ -389,7 +389,7 @@ namespace Toastify.Core
                     if (openSpotifyBlocked)
                     {
                         logger.Error("Couldn't access \"open.spotify.com\": the client blocked the connection to the host.");
-                        throw new ApplicationStartupException(openSpotifyBlockedMessage, false);
+                        throw new ApplicationStartupException(openSpotifyBlockedMessage);
                     }
 
                     if (ex.Status == WebExceptionStatus.ProtocolError)


### PR DESCRIPTION
I'm getting used to the code base and c#. Therefore consider this as practice.

I changed the `ApplicationStartupException` in the following ways:
* The message parameter is mandatory. (I don't see any reason why an Exception without a message might have any value.)
* `CreateMessage()` always considers the `Spotify` class by itself. No reason why the caller should be bothered with any decision about including it or not.
   * Because `Spotify` now instantiates itself on the getter method of the `Instance` field, there is no `null` reference any more. However, the `Spotify` constructor fails if called too early, like during the Logger configuration in `App.xaml.cs`. That's why a `try` is needed instead of a `null` check. An alternative would be to introduce separate Exceptions for different startup phases. But this does not really resonate with me, because this would just be another way of reintroducing the `spotifyStatus` flag that I just intended to get rid of.

Therefore, this simplified the `ApplicationStartupException` constructors to a single one.

For the future I'd like to:
* Add a proper `toString()` method to the `SpotifyAPI.Local.Models.StatusResponse` class. I want to get rid of the problem, that the `ApplicationStartupException` must be aware of the contents of this class.
* Getting rid of the circular dependency between `Spotify` and `ApplicationStartupException`. But this might  be a bigger step. One idea might be to externalize the `Spotify` data into a separate data class.